### PR TITLE
 Removed the part that resized the default figures

### DIFF
--- a/mupet.m
+++ b/mupet.m
@@ -93,9 +93,6 @@ function handles=mupet_initialize(handles)
     % user interface
     makeurl(handles.wiki,'https://github.com/mvansegbroeck/mupet/wiki/MUPET-wiki');
     makeurl(handles.code,'https://github.com/mvansegbroeck/mupet/');
-    defaultFigPos=get(0,'DefaultFigurePosition');
-    defaultFigPos=get(0,'ScreenSize');
-    set(0,'DefaultFigurePosition',[1 defaultFigPos(2) defaultFigPos(3)/10 defaultFigPos(4)/10]);
     [handles.FontSize1, handles.FontSize2, handles.FontSize3, handles.FontSize4]=setGuiFonts(handles);
     set(handles.syllableSlider,'Visible','off');
     set(handles.syllable_axes_fft,'Visible','off');

--- a/mupet.m
+++ b/mupet.m
@@ -89,7 +89,7 @@ function handles=mupet_initialize(handles)
     handles.repertoire_learning_min_nb_syllables_fac=1;
     handles.repertoire_unit_size_seconds=200;
     handles.patch_window=handles.repertoire_unit_size_seconds/handles.frame_shift_ms*1e-3; % ms divided by frameshift
- 
+
     % user interface
     makeurl(handles.wiki,'https://github.com/mvansegbroeck/mupet/wiki/MUPET-wiki');
     makeurl(handles.code,'https://github.com/mvansegbroeck/mupet/');

--- a/mupet.m
+++ b/mupet.m
@@ -89,7 +89,7 @@ function handles=mupet_initialize(handles)
     handles.repertoire_learning_min_nb_syllables_fac=1;
     handles.repertoire_unit_size_seconds=200;
     handles.patch_window=handles.repertoire_unit_size_seconds/handles.frame_shift_ms*1e-3; % ms divided by frameshift
-
+ 
     % user interface
     makeurl(handles.wiki,'https://github.com/mvansegbroeck/mupet/wiki/MUPET-wiki');
     makeurl(handles.code,'https://github.com/mvansegbroeck/mupet/');


### PR DESCRIPTION
Hello MUPET team,

First, thanks for creating this outstanding tool. It has been an excellent asset for the our USV research.
I just have one minor thing: whenever I launch MUPET, the default MATLAB figure size becomes incredibly small, and it took me a while to figure out how to set it back to the factory default (it has to be done through the command line).

I figured I'd add this as a pull request so that this wouldn't happen to other MUPETeers.

Once again, thanks for releasing MUPET as open source!
-Russell